### PR TITLE
fix: k8s scheduler deployment fails

### DIFF
--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -112,9 +112,9 @@ type patchStringValue struct {
 
 var _ framework.QueueSortPlugin = &Coscheduling{}
 var _ framework.PreFilterPlugin = &Coscheduling{}
-var _ framework.ScorePlugin = &Coscheduling{}
 var _ framework.PermitPlugin = &Coscheduling{}
 var _ framework.UnreservePlugin = &Coscheduling{}
+var _ framework.ScorePlugin = &Coscheduling{}
 
 const (
 	// Name is the name of the plugin used in Registry and configurations.


### PR DESCRIPTION
Previously, the score plugin was added to the end of the list. However, the list needs to be ordered in the same way the functions are declared in order to work. This fix reorders the function declaration order such that the helm chart does not need any modification.

previous fix: https://github.com/determined-ai/determined/pull/2805