### PR TITLE
feat: allow consideration of queue positions 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/scheduler-plugins
 go 1.13
 
 require (
+	github.com/shopspring/decimal v1.3.1
 	k8s.io/api v0.18.9
 	k8s.io/apimachinery v0.18.9
 	k8s.io/client-go v0.18.9

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvW
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -266,7 +266,7 @@ func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleSta
 		return framework.NewStatus(framework.Success, "")
 	}
 
-	if time.Since(cs.lastRefresh) > 5 {
+	if time.Since(cs.lastRefresh).Seconds() > 5 {
 		// check the groups to see if they have pods alive
 		for group := range cs.approvedGroups {
 			if cs.calculateTotalPods(group, "default") == 0 {

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -266,7 +266,7 @@ func (cs *Coscheduling) PreFilter(ctx context.Context, state *framework.CycleSta
 		return framework.NewStatus(framework.Success, "")
 	}
 
-	if time.Since(cs.lastRefresh) > 30 {
+	if time.Since(cs.lastRefresh) > 5 {
 		// check the groups to see if they have pods alive
 		for group := range cs.approvedGroups {
 			if cs.calculateTotalPods(group, "default") == 0 {
@@ -391,7 +391,7 @@ func GetPodGroupLabels(pod *v1.Pod) (string, int, decimal.Decimal, error) {
 	}
 	qPosition, err := decimal.NewFromString(qLabel)
 	if err != nil {
-		klog.Errorf("PodGroup %v/%v : PodGroup Queue Position is invalid", pod.Namespace, pod.Name, qLabel)
+		klog.Errorf("PodGroup %v/%v : %s", pod.Namespace, pod.Name, err)
 		return podGroupName, minNum, decimal.Zero, err
 	}
 	return podGroupName, minNum, qPosition, nil

--- a/pkg/coscheduling/coscheduling.go
+++ b/pkg/coscheduling/coscheduling.go
@@ -763,14 +763,15 @@ func (cs *Coscheduling) preemptPods(group *waitingGroup, available int) (bool, i
 		}
 		for _, pod := range node.Pods() {
 			pgInfo, _ := cs.getOrCreatePodGroupInfo(pod, time.Now())
-			if _, ok := pod.Labels["determined-system"]; ok {
-				maximum = SystemPriority
-				bestPos = decimal.Zero
-			} else if _, ok := pod.Labels["determined-cmd"]; ok {
-				maximum = SystemPriority
-				bestPos = decimal.Zero
-			} else if _, ok := pod.Labels["determined"]; !ok { //only count determined pods for preemption
+			if _, ok := pod.Labels["determined"]; !ok { //only count determined pods for preemption
 				continue
+			}
+			if pod.Name[0:2] == "gc" {
+				maximum = SystemPriority
+				bestPos = decimal.Zero
+			} else if pod.Name[0:3] == "cmd" {
+				maximum = SystemPriority
+				bestPos = decimal.Zero
 			}
 			if int(pgInfo.priority) > maximum {
 				maximum = int(*pod.Spec.Priority)


### PR DESCRIPTION
Convert the integer implementation of queue position to a decimal and add code for refreshing pod information and for checking if a group is still alive.